### PR TITLE
WDP181103-36

### DIFF
--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -181,7 +181,7 @@ header {
     
     .search-wrapper {
       display: flex;
-      justify-content: center;
+      justify-content: flex-start;
       align-items: center;
 
       .category-list-show {
@@ -346,6 +346,7 @@ header {
       }
   
       .search-wrapper {
+        justify-content: center;
         padding: 20px 0;
       }
     }


### PR DESCRIPTION
**problem:** umiejscowienie .search-wrapper niezgodne z designem.
**rozwiązanie:** zmieniłem właściwość justify-content  .search-wrapper dla ekranów o szerokości >1200px, aby element był wyrównany do lewej. 